### PR TITLE
Allow non-command message deletion

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1712,6 +1712,8 @@ async def send_desync_help(ctx):
 
 @bot.event
 async def on_message_without_command(message: discord.Message):
+    if message.author.bot:
+        return
     if preferences["delete_non_command"] is False:
         return
     forbidden_channels = [inscriptions_channel_id, check_in_channel_id]

--- a/bot.py
+++ b/bot.py
@@ -1710,6 +1710,16 @@ async def send_desync_help(ctx):
     await ctx.send(desync_text)
 
 
+@bot.event
+async def on_message_without_command(message: discord.Message):
+    if preferences["delete_non_command"] is False:
+        return
+    forbidden_channels = [inscriptions_channel_id, check_in_channel_id]
+    channel = message.channel
+    if channel.id in forbidden_channels and channel.permissions_for(message.guild.me).manage_messages:
+        await message.delete()
+
+
 ### On command error : invoker has not enough permissions
 @bot.event
 async def on_command_error(ctx, error):

--- a/config/preferences.yml
+++ b/config/preferences.yml
@@ -11,3 +11,4 @@ reaction_mode: True
 restrict_to_role: False
 start_bo5: 0 # When to start BO5 (0 = top 8, +1 = top 6, -1 = top 12, etc.)
 use_guild_name: True
+delete_non_commands: False  # Should delete non-commands messages in the inscriptions channel?


### PR DESCRIPTION
This adds a parameter to know if the bot should delete all messages that are not commands in inscriptions and check-in channels.